### PR TITLE
Performance tests for notebooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+services:
+- docker
+script:
+- make build
+- make test
+env:
+  global:
+    # GITHUB_TOKEN (used by .travis.publish.sh)
+    secure: fZZUEtVnaVRa6K/2MUmx9FndqMr3W6VG+cXTalbmDXNRziX5PZ1Ud7qVuMmJFGQKfIqahLQxRHG5ifpzcBjtFuXyO1i7VcvWTyvIUhYNJyot8uuax2U95EpjtMJM1G6b5cPmOy69pxaKHhRywG2d+vscqmH/IkwGoXLJtq3/1HKXNuv/EVfMExT5Nn7RlczmPaCdhR8srKo+v3Vf6vhkQJlfhNvKyQ3sEmMKc49RtQtbrlVeJD+tvHhD4te8qSbqUJ8AR6lSmJQzP4f9fFcV9lmZFZAgy5cQSci/2/0BB/6fEt1GOSIyoEWQspEeLDclJnIrnAD9b6ig2vci1a+wZ9QZKDolvw1HAaZZ+E3lQ+0hAWSc8tVRU5Jj2aXOi0WRztDUN8PKFbRNiSK7HjUvnQaAvIl+hKVCtxaC6CaVU95H/RvviIUpTKDeoeD3LypwBPAPRnOxvSIDSBb2WV5QWtJsmRUy45/5qCvNHE2DCahcYo0x8ScaC3xgvzUoA3XlfzLKRiyoDgWXCgbAe5p8gf12pKquFTlxfxQQ/JUe0Ad671dwj7JpYfxVYbRRjQx8vbx2Soek2U0kV/TzNo16mOC121S5RxmJBHi+8B6ANhaubnlgmHYnFUsuAs5rxiweQ0BMmat4dzGNUxKJXwcy5W5tjtQ/UoWLHrocn5pDXY4=

--- a/.travis/notebooks-perf-test.sh
+++ b/.travis/notebooks-perf-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -x
+
+pip install --user pyspark
+
+# use the png backend for matplotlib
+export MPLBACKEND="Agg"
+
+NOTEBOOKS="ml-basics pyspark var" #var-demo workshop
+for notebook in $NOTEBOOKS ; do
+  [ ! -f "./$notebook.ipynb" ] && echo "Skipping $notebook.ipynb because it doesn't exist" && continue
+
+  echo -e "\n\nRunning the perf test for $notebook\n\n"
+
+  # convert the notebook to executable script
+  jupyter nbconvert --to script $notebook.ipynb --Application.log_level=DEBUG --output=test
+  NBC_CODE=$?
+  # accumulative error xored with other return codes
+  ACC_CODE="$[$NBC_CODE ^ ${ACC_CODE:-0}]"
+  [ $NBC_CODE -ne 0 ] && echo "perf test for $notebook notebook wasn't possible to run" >> all.perf && continue
+
+  # comment out the lines starting with 'get_ipython' (originally %matplotlib or %config)
+  sed -i'' 's/^\(get_ipython.*\)/#\1/' test.py
+
+  # run the notebook and measure the execution time
+  /usr/bin/time -f'%E' -o $notebook.perf -- ipython test.py
+  ACC_CODE="$[$? ^ ${ACC_CODE}]"
+  echo perf test for $notebook notebook took `cat $notebook.perf` >> all.perf
+done
+
+# print results to stdout
+echo -e "\n\nAll results:\n"
+cat all.perf
+
+if [ $ACC_CODE -ne 0 ]; then
+  # failure
+  echo -e "\n\nSome of the tests above failed\n\n"
+  exit $ACC_CODE
+else
+  # success
+  echo -e "\n\nTests were successfuly run\n\n"
+  ./publish.sh
+fi
+
+exit 0

--- a/.travis/publish.sh
+++ b/.travis/publish.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+_results_file="./all-results.perf"
+
+if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ -f "$_results_file" ]; then
+  echo -e "Commenting on PR with the results"
+  curl -i -XPOST -H "Authorization: token $GITHUB_TOKEN" \
+   -d '{"body":"Results:\n'`cat $_results_file`'\n:balloon: :balloon: :balloon:"}' \
+   https://api.github.com/repos/radanalyticsio/workshop-notebook/issues/$TRAVIS_PULL_REQUEST/comments 1>&2
+fi

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# this script is run as a root in the container
+
+yum -y install time

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+LOCAL_IMAGE=$(USER)/workshop-notebook
+TEST_CONTAINER=test-workshop-notebook
+
+.PHONY: build clean run test
+
+build:
+	docker build -t $(LOCAL_IMAGE) .
+
+clean:
+	-docker rmi -f $(LOCAL_IMAGE)
+	-docker rm -f $(TEST_CONTAINER)
+
+run:
+	docker run -p 8888:8888 -e JUPYTER_NOTEBOOK_PASSWORD=developer $(LOCAL_IMAGE)
+
+test:
+	-docker rm -f $(TEST_CONTAINER)
+	# remove the container in 10 minutes (timeout)
+	-(sleep $$[10*60] && docker rm -f $(TEST_CONTAINER))&
+	pid=$$!
+
+	docker run -d -e TRAVIS_PULL_REQUEST="$(TRAVIS_PULL_REQUEST)" --name $(TEST_CONTAINER) $(LOCAL_IMAGE)
+	for f in .travis/setup.sh .travis/notebooks-perf-test.sh .travis/publish.sh ; do \
+		docker cp $$f $(TEST_CONTAINER):/notebooks/ ; \
+	done
+	docker exec --user 0 $(TEST_CONTAINER) /notebooks/setup.sh
+	docker exec $(TEST_CONTAINER) /notebooks/notebooks-perf-test.sh
+	docker rm -f $(TEST_CONTAINER)
+	-kill $(pid)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 LOCAL_IMAGE=$(USER)/workshop-notebook
-TEST_CONTAINER=test-workshop-notebook
+RANDOM := $(shell bash -c 'echo $$$$')
+TEST_CONTAINER="test-workshop-notebook-$(RANDOM)"
+
 
 .PHONY: build clean run test
 
@@ -8,17 +10,11 @@ build:
 
 clean:
 	-docker rmi -f $(LOCAL_IMAGE)
-	-docker rm -f $(TEST_CONTAINER)
 
 run:
 	docker run -p 8888:8888 -e JUPYTER_NOTEBOOK_PASSWORD=developer $(LOCAL_IMAGE)
 
 test:
-	-docker rm -f $(TEST_CONTAINER)
-	# remove the container in 10 minutes (timeout)
-	-(sleep $$[10*60] && docker rm -f $(TEST_CONTAINER))&
-	pid=$$!
-
 	docker run -d -e TRAVIS_PULL_REQUEST="$(TRAVIS_PULL_REQUEST)" --name $(TEST_CONTAINER) $(LOCAL_IMAGE)
 	for f in .travis/setup.sh .travis/notebooks-perf-test.sh .travis/publish.sh ; do \
 		docker cp $$f $(TEST_CONTAINER):/notebooks/ ; \
@@ -26,4 +22,3 @@ test:
 	docker exec --user 0 $(TEST_CONTAINER) /notebooks/setup.sh
 	docker exec $(TEST_CONTAINER) /notebooks/notebooks-perf-test.sh
 	docker rm -f $(TEST_CONTAINER)
-	-kill $(pid)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build status](https://travis-ci.org/radanalyticsio/workshop-notebook.svg?branch=master)](https://travis-ci.org/radanalyticsio/workshop-notebook)
+
 # workshop-notebook
 
-This is a basic Jupyter notebook for learning Spark and OpenShift.  If you just need a Jupyter notebook with PySpark for OpenShift, check out [radanalyticsio/base-notebook](https://github.com/radanalyticsio/base-notebook).
+This is a basic Jupyter notebook for learning Spark and OpenShift. If you just need a Jupyter notebook with PySpark for OpenShift, check out [radanalyticsio/base-notebook](https://github.com/radanalyticsio/base-notebook).


### PR DESCRIPTION
Here is an example of the travis build: https://travis-ci.org/radanalyticsio/workshop-notebook/builds/262333907

It builds the docker image, 'nbconverts' the notebooks that are whitelisted in this [script](https://github.com/radanalyticsio/workshop-notebook/pull/5/files#diff-f03c2f1bbf15e4851915b9d37df426c8R9) and process them. The feature that comments on PRs w/ the results doesn't work yet, because it requires the Travis secret that I am adding by this PR so I guess, it's kind of the chicken-egg problem.

off-topic:
What can be add in the future (not necessarily for this image) is the auto-push to dockerhub only if the tests passes or only if there is a tag on this repo (tag ~ release). So that we can mirror the tags/releases in the docker tags.. master can correspond to the `:latest` tag or `:latest` can point to the 'latest released'.

EDIT: ~~don't merge yet~~