### PR TITLE
Fix to commenting script

### DIFF
--- a/.travis/publish.sh
+++ b/.travis/publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-_results_file="./all-results.perf"
+_results_file="./all.perf"
 
 if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ -f "$_results_file" ]; then
   echo -e "Commenting on PR with the results"

--- a/.travis/publish.sh
+++ b/.travis/publish.sh
@@ -5,6 +5,6 @@ _results_file="./all.perf"
 if [ -n "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ -f "$_results_file" ]; then
   echo -e "Commenting on PR with the results"
   curl -i -XPOST -H "Authorization: token $GITHUB_TOKEN" \
-   -d '{"body":"Results:\n'`cat $_results_file`'\n:balloon: :balloon: :balloon:"}' \
+   -d "{\"body\":\"Results:\n`cat $_results_file | sed ':a;N;$!ba;s/\n/\\n/g'`\n:balloon: :balloon: :balloon:\"}" \
    https://api.github.com/repos/radanalyticsio/workshop-notebook/issues/$TRAVIS_PULL_REQUEST/comments 1>&2
 fi


### PR DESCRIPTION
closing, because I've just realized it can't work :/
the secret env variables are not available in the builds when building the PRs. Travis prohibits this, because attacker could create a PR in which he could print the variable. And making the gh_token public isn't good idea, because it could be stolen.